### PR TITLE
Add blog post: Best AI Coding Tools in 2025

### DIFF
--- a/src/posts/best-ai-coding-tools-2025.md
+++ b/src/posts/best-ai-coding-tools-2025.md
@@ -1,0 +1,106 @@
+---
+title: "The Best AI Coding Tools in 2025: An Honest Comparison"
+description: "A balanced comparison of Claude, GitHub Copilot, Cursor, and Windsurf for AI-assisted coding. Covering code quality, context window, pricing, and developer experience."
+pubDate: 2025-06-15
+author: "Kanr"
+tags: ["ai", "developer tools", "coding", "comparison"]
+---
+
+AI coding assistants have gone from novelty to necessity in under three years. By mid-2025, most professional developers use at least one, and the market has settled around a handful of serious contenders. But they are not interchangeable. Each tool makes different trade-offs around code quality, context handling, pricing, and overall developer experience.
+
+I have spent serious time with all four of the tools covered here. This is my honest take on where each one shines and where it falls short.
+
+## The Contenders
+
+### Claude (Anthropic)
+
+Claude is Anthropic's flagship model, available through the API, the claude.ai web app, and most notably **Claude Code** — a CLI-based coding agent that operates directly in your terminal and file system. Claude Code is the most agentic of the tools here: it reads your codebase, runs commands, edits files, and commits code, all in a conversational loop.
+
+**Strengths:**
+- Best-in-class reasoning on complex, multi-file tasks. Claude consistently produces code that actually works on the first pass for non-trivial problems.
+- Claude Code's agentic workflow is genuinely different from autocomplete. It plans, executes, and iterates — closer to pair programming than suggestion-generation.
+- Excellent at understanding large codebases. The extended context window (up to 200K tokens) means it can hold significant project context in a single conversation.
+- Strong at explaining *why* it made specific decisions, which makes code review faster.
+
+**Weaknesses:**
+- Claude Code requires comfort with the terminal. If you live in a GUI IDE, the workflow is less seamless than Cursor or Copilot.
+- API costs can add up quickly for heavy usage, though the Max subscription helps.
+- Autocomplete is not its primary mode — it is an agent, not a tab-completion engine.
+
+### GitHub Copilot
+
+Copilot is the incumbent. Backed by OpenAI's models and deeply integrated into VS Code and JetBrains, it is the tool most developers have tried first. In 2025, Copilot has expanded well beyond inline suggestions with Copilot Chat, Copilot Workspace, and agent mode in VS Code.
+
+**Strengths:**
+- Unmatched IDE integration. Copilot feels native in VS Code because it essentially is. Tab-completion is fast and contextually aware.
+- Copilot Workspace brings planning and multi-file editing to the GitHub web UI, which is useful for issue-to-PR workflows.
+- The ecosystem is massive: extensions, enterprise features, and tight GitHub integration (PR summaries, code review suggestions).
+- The free tier is generous enough for individual developers to get real value.
+
+**Weaknesses:**
+- Code quality on complex tasks lags behind Claude. Copilot is excellent at boilerplate and pattern completion but less reliable when problems require deep reasoning.
+- Context handling has improved but still struggles with large monorepos. It can miss important context that lives outside the current file.
+- Agent mode is newer and less polished than Claude Code or Cursor's agent features.
+
+### Cursor
+
+Cursor is a fork of VS Code rebuilt around AI-first workflows. It is not a plugin — it is a full IDE with AI capabilities baked into every interaction. Cursor has built a passionate user base by focusing on developer experience above all else.
+
+**Strengths:**
+- The best AI-native IDE experience. Features like Cmd+K inline editing, the composer for multi-file changes, and automatic context detection are slick and well-designed.
+- Codebase indexing means Cursor understands your project structure without manual context management. You can reference files with `@` mentions naturally.
+- Model flexibility: you can use Claude, GPT-4, or other models as the backend, which lets you pick the best model for different tasks.
+- The tab-completion is competitive with Copilot and sometimes better because of richer context.
+
+**Weaknesses:**
+- It is a separate IDE. If your team is standardized on VS Code with specific extensions, switching has friction. Extension compatibility is good but not perfect.
+- Pricing is higher than Copilot for comparable usage, and heavy users can hit rate limits on the Pro plan.
+- Being a startup means less certainty about long-term support compared to GitHub or Anthropic.
+
+### Windsurf (Codeium)
+
+Windsurf, built by the Codeium team, is positioned as an AI-native IDE similar to Cursor. It was originally known for Codeium's strong free-tier autocomplete and has evolved into a full coding environment with agent capabilities called "Cascade."
+
+**Strengths:**
+- Cascade flows are well-designed for multi-step tasks. The agent can plan, execute terminal commands, and edit files in a guided workflow.
+- Competitive pricing with a meaningful free tier, making it accessible for students and individual developers.
+- Good at understanding project context through indexing, similar to Cursor.
+- Supports multiple models and is improving rapidly with frequent updates.
+
+**Weaknesses:**
+- Code quality is a step behind Claude and Cursor for complex reasoning tasks. It handles straightforward tasks well but can struggle with nuanced architectural decisions.
+- The IDE is less mature than Cursor. Some rough edges remain in the editing experience and extension support.
+- Smaller community means fewer resources, tutorials, and shared configurations.
+
+## Comparison Table
+
+| Feature | Claude (Code) | GitHub Copilot | Cursor | Windsurf |
+|---|---|---|---|---|
+| **Code Quality** | Excellent | Good | Very Good | Good |
+| **Context Window** | 200K tokens | ~128K tokens | Varies by model | ~128K tokens |
+| **Autocomplete** | Not primary focus | Excellent | Very Good | Good |
+| **Agentic Capability** | Excellent | Good | Very Good | Good |
+| **IDE Integration** | Terminal (CLI) | VS Code, JetBrains | Own IDE (VS Code fork) | Own IDE |
+| **Multi-file Editing** | Excellent | Good | Very Good | Good |
+| **Pricing (Individual)** | $20-100/mo (Max) | $10-19/mo | $20/mo (Pro) | $15/mo (Pro) |
+| **Free Tier** | Limited | Yes | Limited | Yes |
+| **Model Flexibility** | Claude only | OpenAI models | Multiple (Claude, GPT, etc.) | Multiple |
+| **Best For** | Complex tasks, agents | Everyday autocomplete | AI-native IDE workflow | Budget-friendly AI IDE |
+
+## My Recommendations
+
+**For most developers:** Start with GitHub Copilot. It is the safest bet — low cost, excellent IDE integration, and good enough for daily coding. You will immediately feel more productive on routine tasks.
+
+**For complex projects and senior developers:** Claude (especially Claude Code) is the strongest choice when you need an AI that can reason about architecture, handle multi-file refactors, and produce code that works without hand-holding. The terminal-based workflow is not for everyone, but if you are comfortable there, nothing else matches it for hard problems.
+
+**For the best all-around IDE experience:** Cursor strikes the best balance between code quality, developer experience, and flexibility. Being able to swap models means you are not locked into one provider's strengths and weaknesses.
+
+**For budget-conscious developers and students:** Windsurf offers the most value at lower price points. The free tier is genuinely usable, and the paid plans are competitive.
+
+## The Bigger Picture
+
+The real story of 2025 is not which tool is "best" — it is that AI-assisted coding has become table stakes. The tools are converging in capability while differentiating on workflow. Copilot bets on seamless integration, Claude bets on reasoning depth, Cursor bets on IDE experience, and Windsurf bets on accessibility.
+
+My honest advice: try at least two of these tools on a real project before committing. The best tool is the one that fits how you actually work, not the one that wins benchmarks.
+
+The market is moving fast. By the time you read this, at least one of these tools will have shipped a major update that changes the calculus. That is a good problem to have.


### PR DESCRIPTION
## Summary
- Adds a ~1500-word comparison blog post covering Claude, GitHub Copilot, Cursor, and Windsurf
- Compares on code quality, context window, pricing, and developer experience
- Includes a summary comparison table and per-audience recommendations
- SEO-friendly with descriptive title and meta description

## Test plan
- [ ] Verify the post renders correctly at `/blog/best-ai-coding-tools-2025`
- [ ] Check markdown table renders properly
- [ ] Confirm frontmatter tags and metadata are correct
- [ ] Review dark mode rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)